### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+*.png diff=exif
+*.jpg diff=exif
+*.gif diff=exif
+
+art_src/ export-ignore
+tiled/ export-ignore
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.mailmap export-ignore


### PR DESCRIPTION
This makes releasing tar balls easier, as it automatically will ignore
unneeded files for the release (tiled and art_src folder and the
dot git files)

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
