### PR TITLE
Fix transformation into Juggernaut

### DIFF
--- a/mods/polymorphable/enemies/juggernautd.txt
+++ b/mods/polymorphable/enemies/juggernautd.txt
@@ -2,7 +2,7 @@ name=Juggernaut
 humanoid=true
 level=1
 categories=juggernautd
-rarity=commons
+rarity=common
 xp=0
 
 animations=animations/enemies/juggernaut.txt


### PR DESCRIPTION
Transformation into Juggernaut is currently broken. It costs mana, but otherwise does not go through at all. The following errors are logged:

```
ERROR: EnemyGroupManager: 'rarity' property for enemy 'enemies/juggernautd.txt' not valid (common|uncommon|rare): commons
ERROR: EnemyGroupManager: Could not find a suitable enemy category for (juggernautd, 0, 0)
ERROR: Avatar: Could not transform into creature type 'juggernautd'
```

The rarity of Juggernaut is misspelled and has always been. I wonder how this worked in the past...