### PR TITLE
Fix power description visibility in tooltips

### DIFF
--- a/mods/polymorphable/engine/font_colors.txt
+++ b/mods/polymorphable/engine/font_colors.txt
@@ -16,4 +16,4 @@ combat_miss=128,128,128
 requirements_not_met=255,0,0
 item_bonus=0,255,0
 item_penalty=255,0,0
-
+item_flavor=190,180,170


### PR DESCRIPTION
Previously the description text was black (by default) on black background.